### PR TITLE
OTIS 05 support

### DIFF
--- a/cargo.nut
+++ b/cargo.nut
@@ -216,8 +216,8 @@ function GetEconomyCargoList(economy, cargo_list) {
     case(Economies.OTIS): // OTIS 03
         local list = ["PASS","COAL","MAIL","OIL_","LIME","GOOD","GRAI","WOOD","IORE","STEL",
                       "MILK","FOOD","PAPR","FISH","WOOL","CLAY","SAND","WDPR","PCL_","GRVL",
-                      "FRUT","BDMT","BEER","MAIZ","CMNT","GLAS","LVST","PETR","FRVG","SASH",
-                      "OTI1","CORE","SCMT","COPR","URAN","VALU","AORE","OTI2","NICK","SULP",
+                      "FRUT","BDMT","BEER","MAIZ","CMNT","GLAS","LVST","PETR","FRVG","FICR",
+                      "OTI1","CORE","SCMT","COPR","URAN","VALU","AORE","OTI2","NKOR","SULP",
                       "RUBR","VEHI","BAKE","PIPE","OYST","MEAT","CHSE","FURN","TEXT","SEED",
                       "FERT","BOOM","ACID","CHLO","SLAG","TWOD","SESP","FUEL","ELTR","WATR",
                       "TATO","POWR","MPTS","RFPR"];


### PR DESCRIPTION
From : 
https://www.tt-forums.net/viewtopic.php?t=88584&start=40 
Cargo Nickel no longer has cargolabel NICK, but cargolabel NKOR 
Cargo Cotton no longer has cargolabel SASH, but cargolabel FICR

Changes :
Cargolabel NICK to NKOR
Cargolabel SASH to FICR